### PR TITLE
specify Qt5 matplotlib backend, and auto-close plots

### DIFF
--- a/tests/test_gui/test_bitdepth.py
+++ b/tests/test_gui/test_bitdepth.py
@@ -1,4 +1,7 @@
 import numpy as np
+import matplotlib
+matplotlib.use("Qt5Agg")
+
 from matplotlib.pyplot import cm
 from spimagine import volshow
 import OpenGL.GL as GL

--- a/tests/test_rendering/test_iso_rendering.py
+++ b/tests/test_rendering/test_iso_rendering.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import numpy as np
 from spimagine.volumerender.volumerender import VolumeRenderer
 from spimagine.utils.transform_matrices import *
-import matplotlib.pyplot as plt
+
 import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tests/test_rendering/test_simple_rendering.py
+++ b/tests/test_rendering/test_simple_rendering.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import
 import numpy as np
 from spimagine.volumerender.volumerender import VolumeRenderer
 from spimagine.utils.transform_matrices import *
+import matplotlib
+matplotlib.use("Qt5Agg")
 import matplotlib.pyplot as plt
 import logging
 logger = logging.getLogger(__name__)
@@ -42,9 +44,12 @@ def test_simple_rendering():
         plt.imshow(out)
         plt.axis("off")
         plt.title("%s"%(dtype))
+    plt.pause(.1)
+    plt.close()
 
     plt.show()
-    plt.pause(2)
+    plt.pause(.1)
+    plt.close()
     return rend
 
 def test_surface():
@@ -70,9 +75,11 @@ def test_surface():
 
     plt.imshow(rend.output)
     plt.axis("off")
+    plt.close()
 
     plt.show()
     plt.pause(.1)
+    plt.close()
     return rend
 
 

--- a/tests/test_utils/test_alpha_shape.py
+++ b/tests/test_utils/test_alpha_shape.py
@@ -8,7 +8,8 @@ from __future__ import absolute_import
 import numpy as np
 from spimagine import volfig, Mesh, qt_exec
 from spimagine.utils import alpha_shape
-
+import matplotlib
+matplotlib.use("Qt5Agg")
 
 def test_2d():
     import matplotlib.pyplot as plt
@@ -40,7 +41,8 @@ def test_2d():
         plt.plot(points[edge, 0], points[edge, 1], "k", lw=2)
 
     plt.axis("equal")
-
+    plt.pause(0.1)
+    plt.close()
 
     return points, normals, indices
 

--- a/tests/test_volumerender/test_volumerender.py
+++ b/tests/test_volumerender/test_volumerender.py
@@ -7,6 +7,8 @@ from __future__ import print_function, unicode_literals, absolute_import, divisi
 import numpy as np
 from spimagine.volumerender.volumerender import VolumeRenderer
 from spimagine.utils import mat4_translate
+import matplotlib
+matplotlib.use("Qt5Agg")
 
 # two test functions to get the ray coordinates in the kernel...
 def _getOrig(P, M, u=1, v=0):
@@ -38,6 +40,9 @@ def test_simple():
     out = rend.output
     plt.imshow(out)
     plt.show()
+    plt.pause(0.1)
+    plt.close()
+    return 1
 
 def test_time_to_render():
     import time


### PR DESCRIPTION
was getting some crashes in tests
```
2017-09-27 15:36:12.162 python[3428:173511] -[QNSApplication _setup:]: unrecognized selector sent to instance 0x7f9f18224d00
2017-09-27 15:36:12.165 python[3428:173511] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[QNSApplication _setup:]: unrecognized selector sent to instance 0x7f9f18224d00'
...
libc++abi.dylib: terminating with uncaught exception of type NSException
```
solved by explicitly specifying Qt5 for matplotlib backend.

Also, auto-close a few matplotlib plots so that the tests can run unobserved (necessary for conda builds)

removed one unused matplotlib import
