### PR TITLE
Add line and text annotations

### DIFF
--- a/spimagine/gui/glwidget.py
+++ b/spimagine/gui/glwidget.py
@@ -592,6 +592,9 @@ class GLWidget(QtOpenGL.QGLWidget):
 
         self._mat_modelviewproject = np.dot(self._mat_proj, self._mat_modelview)
 
+        for (m, vbo_verts, vbo_normals, vbo_indices) in self.meshes:
+            self._paintGL_mesh(m, vbo_verts, vbo_normals, vbo_indices)
+
         if self.dataModel:
 
             self.textureAlpha = fillTexture2d(self.output_alpha, self.textureAlpha)
@@ -603,9 +606,6 @@ class GLWidget(QtOpenGL.QGLWidget):
                 self._paintGL_slice()
 
             self._paintGL_render()
-
-        for (m, vbo_verts, vbo_normals, vbo_indices) in self.meshes:
-            self._paintGL_mesh(m, vbo_verts, vbo_normals, vbo_indices)
 
     def render(self):
         logger.debug("render")

--- a/spimagine/gui/lines.py
+++ b/spimagine/gui/lines.py
@@ -1,0 +1,12 @@
+class Lines(object):
+
+    def __init__(self,
+                 vertices=[[0, 0, 0], [1, 0, 0], [1, 1, 0]],
+                 linecolor=(1., 1., 1.),
+                 alpha=.6,
+                 width=1.0):
+
+        self.vertices = vertices
+        self.linecolor = linecolor
+        self.alpha = alpha
+        self.width = width

--- a/spimagine/gui/text.py
+++ b/spimagine/gui/text.py
@@ -1,0 +1,17 @@
+from OpenGL.GLUT import GLUT_BITMAP_9_BY_15
+
+class Text(object):
+
+    def __init__(self,
+                 text,
+                 pos=(0., 0., 0.),
+                 color=(1., 1., 1.),
+                 alpha=.6,
+                 font=GLUT_BITMAP_9_BY_15):
+
+        self.text = text
+        self.position = tuple(pos)
+        self.color = color
+        self.alpha = alpha
+        self.font = font
+


### PR DESCRIPTION
This PR adds `Lines` and `Text` annotations to spimagine, similar to how `Mesh`es are added.
![spimagine](https://user-images.githubusercontent.com/776708/52970301-5a485b80-3381-11e9-9515-d55a65c3cea2.png)
